### PR TITLE
Ignore value of speaker_id if there's only one speaker

### DIFF
--- a/src/python_run/piper/voice.py
+++ b/src/python_run/piper/voice.py
@@ -156,6 +156,8 @@ class PiperVoice:
         if (self.config.num_speakers > 1) and (speaker_id is None):
             # Default speaker
             speaker_id = 0
+        elif self.config.num_speakers == 1:
+            speaker_id = None
 
         sid = None
 


### PR DESCRIPTION
I set `speaker_id = 0` for a single-speaker model and everything blew up with a non-obvious error. This change essentially ignores the `speaker_id` parameter if there's only one speaker in the model.